### PR TITLE
display long left correctly

### DIFF
--- a/apps/nextjs-web/app/components/info-card/link.tsx
+++ b/apps/nextjs-web/app/components/info-card/link.tsx
@@ -2,7 +2,7 @@ export const Link = ({ url }: { url: string }) => (
   <div>
     <span>Quelle: </span>
     <a
-      className="text-blue-500"
+      className="text-blue-500 line-clamp-2"
       href={url}
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
close #82 

the link was limited to two lines and is cut off at the end

<img width="706" alt="Screenshot 2023-09-13 at 15 04 07" src="https://github.com/progwise/george-ai/assets/104686677/5ae0b3f3-1397-4c4a-bbf3-d4452d2817b2">
