### PR TITLE
keywords number bug

### DIFF
--- a/apps/playwright-scraper/src/chat-gpt.ts
+++ b/apps/playwright-scraper/src/chat-gpt.ts
@@ -42,11 +42,12 @@ export const getKeywords = async (content: string, keywordPrompt: string[]) => {
   if (!response) {
     return []
   }
-  const keywords = /^\d+\./.test(response)
-    ? response.split('\n')
-    : response.split(',')
+  const keywords =
+    /^\d+\./.test(response) || /^-\s/.test(response)
+      ? response.split('\n')
+      : response.split(',')
 
   return keywords
-    .map((word) => word.replace(/^\d+\.\s*|,$/, '').trim())
+    .map((word) => word.replace(/^\d+\.\s*|^-?\s*|,$/, '').trim())
     .slice(0, 10)
 }

--- a/apps/playwright-scraper/src/chat-gpt.ts
+++ b/apps/playwright-scraper/src/chat-gpt.ts
@@ -39,9 +39,14 @@ export const getSummary = async (content: string, summaryPrompt: string[]) => {
 
 export const getKeywords = async (content: string, keywordPrompt: string[]) => {
   const response = await createChatCompletion(content, keywordPrompt)
+  if (!response) {
+    return []
+  }
+  const keywords = /^\d+\./.test(response)
+    ? response.split('\n')
+    : response.split(',')
 
-  return response
-    ?.split(',')
-    .map((word) => word.replace(/Keywords: \n1\. |^\d+\. |\.$/, '').trim())
+  return keywords
+    .map((word) => word.replace(/^\d+\.\s*|,$/, '').trim())
     .slice(0, 10)
 }


### PR DESCRIPTION
close #139 

- Added a check for the `response` variable to handle the case where it might be undefined.
- The single `.split(',')` method has been replaced with a conditional split based on whether the `response` starts with a digit followed by a period. 