### PR TITLE
remove shift

### DIFF
--- a/apps/playwright-scraper/src/main.ts
+++ b/apps/playwright-scraper/src/main.ts
@@ -24,11 +24,8 @@ const processPage = async (): Promise<void> => {
     let urlsTodo = [{ url: startUrl, depth: 0 }]
 
     while (urlsTodo.length > 0 && runCounter < MAX_RUNS) {
-      const nextUrlTodo = urlsTodo.shift()
-      if (!nextUrlTodo) {
-        console.log('No more URLs to process')
-        break
-      }
+      const [nextUrlTodo, ...remainingUrls] = urlsTodo
+      urlsTodo = remainingUrls
 
       const { url: currentUrl, depth: currentDepth } = nextUrlTodo
       urlsDone.add(currentUrl)


### PR DESCRIPTION
close #143 

- Replaced the usage of Array.shift() method with array destructuring to safely extract the first element from the urlsTodo array.
- This ensures that nextUrlTodo is never undefined, eliminating the need for the extra check.
