### PR TITLE
fix: Languages not detected on iPhone

### DIFF
--- a/apps/chat-web/app/i18n/get-language.ts
+++ b/apps/chat-web/app/i18n/get-language.ts
@@ -1,7 +1,7 @@
 import { getTranslatedValue } from './use-translation-hook'
 
 const getLanguageString = (languages: readonly string[]) => {
-  return languages.findIndex((language) => language.startsWith('de')) ? 'de' : 'en'
+  return languages.findIndex((language) => language.startsWith('de')) > -1 ? 'de' : 'en'
 }
 
 const getLanguage = async () => {


### PR DESCRIPTION
On iPhone I got always english results even in german settings. This is just a more robust implementation of evaluating if it is german or english.