### PR TITLE
fix: user not loading on library detail page on initial load

### DIFF
--- a/apps/chat-web/app/auth/auth-hook.ts
+++ b/apps/chat-web/app/auth/auth-hook.ts
@@ -32,7 +32,7 @@ export const useAuth = () => {
       const keycloak = new Keycloak(config)
 
       if (typeof window !== 'undefined' && !keycloak.didInitialize) {
-        keycloak.init({
+        await keycloak.init({
           onLoad: 'check-sso',
         })
       }


### PR DESCRIPTION
I noticed that when you reload the library detail page, the user is not loaded and therefore the files are not loaded either.