### PR TITLE
refactor(ai-act): add missing nullables to all aiAct graphql fields

### DIFF
--- a/apps/chat-web/app/components/assistant/assistant-ai-act/ai-act-guide.tsx
+++ b/apps/chat-web/app/components/assistant/assistant-ai-act/ai-act-guide.tsx
@@ -11,7 +11,7 @@ interface AiActGuideProps {
 
 export const AiActGuide = ({ assistantId }: AiActGuideProps) => {
   const { data, isLoading } = useSuspenseQuery(getChecklistStep1QueryOptions(assistantId))
-  if (isLoading || !data || !data.AiActAssessmentQuery) {
+  if (isLoading || !data) {
     return <LoadingSpinner />
   }
   return (

--- a/apps/chat-web/app/components/assistant/assistant-ai-act/assistant-survey.tsx
+++ b/apps/chat-web/app/components/assistant/assistant-ai-act/assistant-survey.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 
 import { FragmentType, graphql, useFragment } from '../../../gql'
 import { useTranslation } from '../../../i18n/use-translation-hook'
-import { LoadingSpinner } from '../../loading-spinner'
 import { getChecklistStep1QueryOptions, resetAssessment, updateBasicSystemInfo } from './checklist-server'
 import QuestionCard from './question-card'
 
@@ -104,7 +103,7 @@ export const AssistantSurvey = (props: AssistantSurveyProps) => {
   })
   const formRef = React.useRef<HTMLFormElement>(null)
 
-  const riskIndicator = assistantSurvey?.riskIndicator
+  const riskIndicator = assistantSurvey.riskIndicator
 
   // Handle response changes
   const handleResponseChange = (questionId: string, value?: string | null, notes?: string | null) => {
@@ -113,10 +112,6 @@ export const AssistantSurvey = (props: AssistantSurveyProps) => {
     formData.append('value', value ?? '')
     formData.append('notes', notes ?? '')
     update(formData)
-  }
-
-  if (!assistantSurvey || !riskIndicator) {
-    return <LoadingSpinner />
   }
 
   return (
@@ -136,7 +131,7 @@ export const AssistantSurvey = (props: AssistantSurveyProps) => {
       <div className="mb-6 space-y-4">
         <form ref={formRef}>
           <input type="hidden" name="assistantId" value={assistantId} />
-          {assistantSurvey.questions?.map((question) => (
+          {assistantSurvey.questions.map((question) => (
             <QuestionCard
               key={`${question.id}-${question.value}`}
               question={question.title[language]}
@@ -159,7 +154,7 @@ export const AssistantSurvey = (props: AssistantSurveyProps) => {
         <p className="mb-3 text-sm text-gray-600">{assistantSurvey.actionsTitle[language]}</p>
         <ul className="mb-4 list-inside list-disc space-y-1 text-sm text-gray-600">
           {assistantSurvey.actions
-            ?.filter((action) => action.level === riskIndicator.level)
+            .filter((action) => action.level === riskIndicator.level)
             .map((action) => (
               <li
                 key={`${action.level}_${action.description[language]}`}

--- a/apps/chat-web/app/components/assistant/assistant-ai-act/risk-identification.tsx
+++ b/apps/chat-web/app/components/assistant/assistant-ai-act/risk-identification.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react'
 
 import { FragmentType, graphql, useFragment } from '../../../gql'
 import { useTranslation } from '../../../i18n/use-translation-hook'
-import { LoadingSpinner } from '../../loading-spinner'
 import { ComplianceArea } from './compliance-area'
 
 const RiskAreasIdentification_AssessmentFragment = graphql(`
@@ -82,17 +81,17 @@ export const RiskAreasIdentification = (props: RiskAreasIdentificationProps) => 
   const { t, language } = useTranslation()
   const assessment = useFragment(RiskAreasIdentification_AssessmentFragment, props.assessment)
   const basicInfo = assessment.assistantSurvey
-  const riskIndicator = basicInfo?.riskIndicator
+  const riskIndicator = basicInfo.riskIndicator
   const questions = basicInfo.questions
   const identifyRiskInfo = assessment.identifyRiskInfo
-  const complianceAreas = identifyRiskInfo?.complianceAreas
+  const complianceAreas = identifyRiskInfo.complianceAreas
 
   // State for selected compliance areas
   const [selectedAreas, setSelectedAreas] = useState<string[]>([])
 
   // Determine EU AI Act applicability
   const euOperation = useMemo(
-    () => questions?.find((q) => q.id === 'euOperation')?.value === 'Yes' || false,
+    () => questions.find((q) => q.id === 'euOperation')?.value === 'Yes' || false,
     [questions],
   )
 
@@ -103,16 +102,14 @@ export const RiskAreasIdentification = (props: RiskAreasIdentificationProps) => 
       return areas
     }
 
-    if (riskIndicator) {
-      if (riskIndicator.level === 'high') {
-        areas.add('documentation')
-        areas.add('governance')
-      } else if (riskIndicator.level === 'medium') {
-        areas.add('documentation')
-      }
+    if (riskIndicator.level === 'high') {
+      areas.add('documentation')
+      areas.add('governance')
+    } else if (riskIndicator.level === 'medium') {
+      areas.add('documentation')
     }
 
-    questions?.forEach((q) => {
+    questions.forEach((q) => {
       switch (q.id) {
         case 'systemType':
           if (q.value === 'ML' || q.value === 'Both') {
@@ -147,10 +144,6 @@ export const RiskAreasIdentification = (props: RiskAreasIdentificationProps) => 
 
     return areas
   }, [euOperation, questions, riskIndicator, selectedAreas])
-
-  if (!basicInfo || !riskIndicator || !questions || !identifyRiskInfo || !complianceAreas) {
-    return <LoadingSpinner />
-  }
 
   // Handle area selection change
   const handleAreaChange = (area: string) => {
@@ -214,7 +207,7 @@ export const RiskAreasIdentification = (props: RiskAreasIdentificationProps) => 
         <div className="flex items-start">
           <span className="mr-3 mt-1 text-2xl">{getRiskIcon()}</span>
           <div className="flex-1">
-            <p className="text-lg font-medium">{riskIndicator.description?.[language]}</p>
+            <p className="text-lg font-medium">{riskIndicator.description[language]}</p>
 
             {!euOperation && (
               <div className="mt-3 rounded bg-white bg-opacity-50 p-3">

--- a/apps/chat-web/app/gql/graphql.ts
+++ b/apps/chat-web/app/gql/graphql.ts
@@ -42,14 +42,14 @@ export type AiActAssessment = {
 /** AI Act Assessment Basic System Info */
 export type AiActAssistantSurvey = {
   __typename?: 'AiActAssistantSurvey'
-  actions?: Maybe<Array<AiActRecommendedAction>>
+  actions: Array<AiActRecommendedAction>
   actionsTitle: AiActString
   assistantId: Scalars['String']['output']
   hint: AiActString
   id: Scalars['String']['output']
-  percentCompleted?: Maybe<Scalars['Int']['output']>
-  questions?: Maybe<Array<AiActQuestions>>
-  riskIndicator?: Maybe<AiActRiskIndicator>
+  percentCompleted: Scalars['Int']['output']
+  questions: Array<AiActQuestions>
+  riskIndicator: AiActRiskIndicator
   title: AiActString
 }
 
@@ -104,9 +104,9 @@ export type AiActRecommendedAction = {
 /** AI Act Risk Indicator */
 export type AiActRiskIndicator = {
   __typename?: 'AiActRiskIndicator'
-  description?: Maybe<AiActString>
+  description: AiActString
   factors: Array<AiActString>
-  level?: Maybe<Scalars['String']['output']>
+  level: Scalars['String']['output']
 }
 
 export type AiActString = {
@@ -348,14 +348,14 @@ export type Mutation = {
   removeConversationParticipant?: Maybe<AiConversationParticipant>
   removeLibraryUsage?: Maybe<AiLibraryUsage>
   removeUserProfile?: Maybe<UserProfile>
-  resetAssessmentAnswers?: Maybe<Scalars['DateTime']['output']>
+  resetAssessmentAnswers: Scalars['DateTime']['output']
   runAiLibraryCrawler?: Maybe<AiLibraryCrawler>
   sendConfirmationMail?: Maybe<Scalars['Boolean']['output']>
   sendMessage: Array<AiConversationMessage>
   unhideMessage?: Maybe<AiConversationMessage>
   updateAiAssistant?: Maybe<AiAssistant>
   updateAiLibrary?: Maybe<AiLibrary>
-  updateAssessmentQuestion?: Maybe<Scalars['DateTime']['output']>
+  updateAssessmentQuestion: Scalars['DateTime']['output']
   updateLibraryUsage?: Maybe<AiLibraryUsage>
   updateMessage?: Maybe<AiConversationMessage>
   updateUserProfile?: Maybe<UserProfile>
@@ -545,7 +545,7 @@ export type MutationUpsertAiBaseCasesArgs = {
 
 export type Query = {
   __typename?: 'Query'
-  AiActAssessmentQuery?: Maybe<AiActAssessment>
+  AiActAssessmentQuery: AiActAssessment
   aiAssistant?: Maybe<AiAssistant>
   aiAssistants: Array<AiAssistant>
   aiConversation?: Maybe<AiConversation>
@@ -878,14 +878,14 @@ export type AssistantSurvey_AssessmentFragment = {
   assistantId: string
   assistantSurvey: {
     __typename?: 'AiActAssistantSurvey'
-    percentCompleted?: number | null
+    percentCompleted: number
     actionsTitle: { __typename?: 'AiActString'; de: string; en: string }
-    actions?: Array<{
+    actions: Array<{
       __typename?: 'AiActRecommendedAction'
       level: string
       description: { __typename?: 'AiActString'; de: string; en: string }
-    }> | null
-    questions?: Array<{
+    }>
+    questions: Array<{
       __typename?: 'AiActQuestions'
       id: string
       notes?: string | null
@@ -903,15 +903,15 @@ export type AssistantSurvey_AssessmentFragment = {
           description: { __typename?: 'AiActString'; de: string; en: string }
         } | null
       }>
-    }> | null
+    }>
     title: { __typename?: 'AiActString'; en: string; de: string }
     hint: { __typename?: 'AiActString'; en: string; de: string }
-    riskIndicator?: {
+    riskIndicator: {
       __typename?: 'AiActRiskIndicator'
-      level?: string | null
-      description?: { __typename?: 'AiActString'; de: string; en: string } | null
+      level: string
+      description: { __typename?: 'AiActString'; de: string; en: string }
       factors: Array<{ __typename?: 'AiActString'; de: string; en: string }>
-    } | null
+    }
   }
 } & { ' $fragmentName'?: 'AssistantSurvey_AssessmentFragment' }
 
@@ -921,14 +921,12 @@ export type AiActAssessmentQueryQueryVariables = Exact<{
 
 export type AiActAssessmentQueryQuery = {
   __typename?: 'Query'
-  AiActAssessmentQuery?:
-    | ({ __typename?: 'AiActAssessment' } & {
-        ' $fragmentRefs'?: {
-          RiskAreasIdentification_AssessmentFragment: RiskAreasIdentification_AssessmentFragment
-          AssistantSurvey_AssessmentFragment: AssistantSurvey_AssessmentFragment
-        }
-      })
-    | null
+  AiActAssessmentQuery: { __typename?: 'AiActAssessment' } & {
+    ' $fragmentRefs'?: {
+      RiskAreasIdentification_AssessmentFragment: RiskAreasIdentification_AssessmentFragment
+      AssistantSurvey_AssessmentFragment: AssistantSurvey_AssessmentFragment
+    }
+  }
 }
 
 export type UpdateAssessmentQuestionMutationVariables = Exact<{
@@ -938,13 +936,13 @@ export type UpdateAssessmentQuestionMutationVariables = Exact<{
   notes?: InputMaybe<Scalars['String']['input']>
 }>
 
-export type UpdateAssessmentQuestionMutation = { __typename?: 'Mutation'; updateAssessmentQuestion?: string | null }
+export type UpdateAssessmentQuestionMutation = { __typename?: 'Mutation'; updateAssessmentQuestion: string }
 
 export type ResetAssessmentAnswersMutationVariables = Exact<{
   assistantId: Scalars['String']['input']
 }>
 
-export type ResetAssessmentAnswersMutation = { __typename?: 'Mutation'; resetAssessmentAnswers?: string | null }
+export type ResetAssessmentAnswersMutation = { __typename?: 'Mutation'; resetAssessmentAnswers: string }
 
 export type RiskAreasIdentification_AssessmentFragment = {
   __typename?: 'AiActAssessment'
@@ -965,7 +963,7 @@ export type RiskAreasIdentification_AssessmentFragment = {
   }
   assistantSurvey: {
     __typename?: 'AiActAssistantSurvey'
-    questions?: Array<{
+    questions: Array<{
       __typename?: 'AiActQuestions'
       id: string
       notes?: string | null
@@ -982,13 +980,13 @@ export type RiskAreasIdentification_AssessmentFragment = {
           description: { __typename?: 'AiActString'; de: string; en: string }
         } | null
       }>
-    }> | null
-    riskIndicator?: {
+    }>
+    riskIndicator: {
       __typename?: 'AiActRiskIndicator'
-      level?: string | null
-      description?: { __typename?: 'AiActString'; de: string; en: string } | null
+      level: string
+      description: { __typename?: 'AiActString'; de: string; en: string }
       factors: Array<{ __typename?: 'AiActString'; de: string; en: string }>
-    } | null
+    }
   }
 } & { ' $fragmentName'?: 'RiskAreasIdentification_AssessmentFragment' }
 

--- a/apps/chat-web/app/gql/schema.graphql
+++ b/apps/chat-web/app/gql/schema.graphql
@@ -25,14 +25,14 @@ type AiActAssessment {
 AI Act Assessment Basic System Info
 """
 type AiActAssistantSurvey {
-  actions: [AiActRecommendedAction!]
+  actions: [AiActRecommendedAction!]!
   actionsTitle: AiActString!
   assistantId: String!
   hint: AiActString!
   id: String!
-  percentCompleted: Int
-  questions: [AiActQuestions!]
-  riskIndicator: AiActRiskIndicator
+  percentCompleted: Int!
+  questions: [AiActQuestions!]!
+  riskIndicator: AiActRiskIndicator!
   title: AiActString!
 }
 
@@ -90,9 +90,9 @@ type AiActRecommendedAction {
 AI Act Risk Indicator
 """
 type AiActRiskIndicator {
-  description: AiActString
+  description: AiActString!
   factors: [AiActString!]!
-  level: String
+  level: String!
 }
 
 type AiActString {
@@ -339,14 +339,14 @@ type Mutation {
   removeConversationParticipant(id: String!): AiConversationParticipant
   removeLibraryUsage(assistantId: String!, libraryId: String!): AiLibraryUsage
   removeUserProfile(userId: String!): UserProfile
-  resetAssessmentAnswers(assistantId: String!): DateTime
+  resetAssessmentAnswers(assistantId: String!): DateTime!
   runAiLibraryCrawler(crawlerId: String!, userId: String!): AiLibraryCrawler
   sendConfirmationMail(confirmationUrl: String!, userId: String!): Boolean
   sendMessage(data: AiConversationMessageInput!, userId: String!): [AiConversationMessage!]!
   unhideMessage(messageId: String!): AiConversationMessage
   updateAiAssistant(data: AiAssistantInput!, id: String!): AiAssistant
   updateAiLibrary(data: AiLibraryInput!, id: String!): AiLibrary
-  updateAssessmentQuestion(assistantId: String!, notes: String, questionId: String!, value: String): DateTime
+  updateAssessmentQuestion(assistantId: String!, notes: String, questionId: String!, value: String): DateTime!
   updateLibraryUsage(id: String!, usedFor: String): AiLibraryUsage
   updateMessage(content: String!, messageId: String!): AiConversationMessage
   updateUserProfile(input: UserProfileInput!, userId: String!): UserProfile
@@ -354,7 +354,7 @@ type Mutation {
 }
 
 type Query {
-  AiActAssessmentQuery(assistantId: String!): AiActAssessment
+  AiActAssessmentQuery(assistantId: String!): AiActAssessment!
   aiAssistant(id: String!): AiAssistant
   aiAssistants(ownerId: String!): [AiAssistant!]!
   aiConversation(conversationId: String!): AiConversation

--- a/packages/pothos-graphql/src/graphql/ai-act-assessment/assistant-survey.ts
+++ b/packages/pothos-graphql/src/graphql/ai-act-assessment/assistant-survey.ts
@@ -63,8 +63,8 @@ export const AiActAssistantSurveyRef = builder
       hint: t.expose('hint', { type: AiActStringRef, nullable: false }),
       assistantId: t.exposeString('assistantId', { nullable: false }),
       id: t.exposeString('id', { nullable: false }),
-      percentCompleted: t.field({
-        type: 'Int',
+      percentCompleted: t.int({
+        nullable: false,
         resolve: async (source) => {
           const answerCount = await prisma.aiAssistantEUActAnswers.count({
             where: { assistantId: source.assistantId },
@@ -74,6 +74,7 @@ export const AiActAssistantSurveyRef = builder
       }),
       questions: t.field({
         type: [AiActQuestionsRef],
+        nullable: false,
         resolve: async (source) => {
           const answers = await prisma.aiAssistantEUActAnswers.findMany({
             where: { assistantId: source.assistantId },
@@ -91,6 +92,7 @@ export const AiActAssistantSurveyRef = builder
       }),
       riskIndicator: t.field({
         type: AiActRiskIndicatorRef,
+        nullable: false,
         resolve: async (source) => {
           const answers = await prisma.aiAssistantEUActAnswers.findMany({
             where: { assistantId: source.assistantId },
@@ -119,6 +121,7 @@ export const AiActAssistantSurveyRef = builder
       actionsTitle: t.expose('actionsTitle', { type: AiActStringRef, nullable: false }),
       actions: t.field({
         type: [AiActRecommendedActionRef],
+        nullable: false,
         resolve: (source) => {
           return source.actions.map((action) => ({
             level: action.level,

--- a/packages/pothos-graphql/src/graphql/ai-act-assessment/index.ts
+++ b/packages/pothos-graphql/src/graphql/ai-act-assessment/index.ts
@@ -55,6 +55,7 @@ builder.queryField('AiActAssessmentQuery', (t) =>
       assistantId: t.arg.string({ required: true }),
     },
     type: AiActAssessment,
+    nullable: false,
     resolve: (_parent, args) => {
       return { assistantId: args.assistantId }
     },

--- a/packages/pothos-graphql/src/graphql/ai-act-assessment/mutations.ts
+++ b/packages/pothos-graphql/src/graphql/ai-act-assessment/mutations.ts
@@ -6,6 +6,7 @@ import { builder } from '../builder'
 builder.mutationField('resetAssessmentAnswers', (t) =>
   t.field({
     type: 'DateTime',
+    nullable: false,
     args: {
       assistantId: t.arg.string({ required: true }),
     },
@@ -24,6 +25,7 @@ builder.mutationField('resetAssessmentAnswers', (t) =>
 builder.mutationField('updateAssessmentQuestion', (t) =>
   t.field({
     type: 'DateTime',
+    nullable: false,
     args: {
       assistantId: t.arg.string({ required: true }),
       questionId: t.arg.string({ required: true }),

--- a/packages/pothos-graphql/src/graphql/ai-act-assessment/risk-indicator.ts
+++ b/packages/pothos-graphql/src/graphql/ai-act-assessment/risk-indicator.ts
@@ -6,8 +6,8 @@ import { AiActStringRef } from './multilingual-string'
 export const AiActRiskIndicatorRef = builder.objectRef<AiActRiskIndicator>('AiActRiskIndicator').implement({
   description: 'AI Act Risk Indicator',
   fields: (t) => ({
-    level: t.exposeString('level'),
-    description: t.expose('description', { type: AiActStringRef }),
+    level: t.exposeString('level', { nullable: false }),
+    description: t.expose('description', { type: AiActStringRef, nullable: false }),
     factors: t.expose('factors', { nullable: false, type: [AiActStringRef] }),
   }),
 })


### PR DESCRIPTION
I think we should keep these types as simple as possible. I have removed all unnecessary `null`s and the corresponding optional chainings