### PR TITLE
fix: conversation entries automatically update

### DIFF
--- a/apps/chat-web/app/components/conversation/conversation-participants.tsx
+++ b/apps/chat-web/app/components/conversation/conversation-participants.tsx
@@ -65,6 +65,10 @@ export const ConversationParticipants = (props: ConversationParticipantsProps) =
       await queryClient.invalidateQueries({
         queryKey: [queryKeys.Conversation, conversation.id],
       })
+
+      await queryClient.invalidateQueries({
+        queryKey: [queryKeys.Conversations, user?.id],
+      })
     },
   })
 


### PR DESCRIPTION
Closes: #333 
Deleting a participant triggers update of the conversation entry now.
The conversation entries get already updated automatically in all other cases.