### PR TITLE
fix: truncates display of assistant description

### DIFF
--- a/apps/chat-web/app/components/assistant/assistant-card.tsx
+++ b/apps/chat-web/app/components/assistant/assistant-card.tsx
@@ -46,7 +46,7 @@ export const AssistantCard = (props: AssistantCardProps): React.ReactElement => 
       </figure>
       <div className="card-body p-4">
         <h2 className="card-title">{assistant.name}</h2>
-        <p className="md:line-clamp-20 line-clamp-10">{assistant.description}</p>
+        <p className="line-clamp-3">{assistant.description}</p>
         <div className="card-actions flex-wrap justify-end">
           <div className="flex gap-2">
             <div className="badge badge-outline">OpenAI</div>


### PR DESCRIPTION
Closes #496 
Truncates the display of assistant description on assistants view.
![assistant_description](https://github.com/user-attachments/assets/953ae21e-a479-405f-8a0f-43e11fbfccdb)
