### PR TITLE
fix: 20250429145637_add_assistant_participation

### DIFF
--- a/packages/pothos-graphql/prisma/migrations/20250429145637_add_assistant_participation/migration.sql
+++ b/packages/pothos-graphql/prisma/migrations/20250429145637_add_assistant_participation/migration.sql
@@ -15,8 +15,9 @@ CREATE UNIQUE INDEX "AiAssistantParticipant_assistantId_userId_key" ON "AiAssist
 ALTER TABLE "AiAssistantParticipant" ADD CONSTRAINT "AiAssistantParticipant_assistantId_fkey" FOREIGN KEY ("assistantId") REFERENCES "AiAssistant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- Populate AiAssistantParticipant with data from existing assistants
-INSERT INTO "AiAssistantParticipant" ("assistantId", "userId")
+INSERT INTO "AiAssistantParticipant" ("id", "assistantId", "userId")
 SELECT
+  gen_random_uuid(),
   a."id" as "assistantId",
   a."ownerId" as "userId"
 FROM "AiAssistant" a;


### PR DESCRIPTION
…rations table if you already applied

20250429145637_add_assistant_participation failed because of id column in AiAssistantParticipant

I changed the already existing migration. 

```
Error: P3018

A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve

Migration name: 20250429145637_add_assistant_participation

Database error code: 23502

Database error:
ERROR: null value in column "id" of relation "AiAssistantParticipant" violates not-null constraint
DETAIL: Failing row contains (null, 2025-05-13 06:04:26.332, cmae388m6000zrtu48l26exuf, cm9uvs9p70000o3qvmoziqlnl).

DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E23502), message: "null value in column \"id\" of relation \"AiAssistantParticipant\" violates not-null constraint", detail: Some("Failing row contains (null, 2025-05-13 06:04:26.332, cmae388m6000zrtu48l26exuf, cm9uvs9p70000o3qvmoziqlnl)."), hint: None, position: None, where_: None, schema: Some("public"), table: Some("AiAssistantParticipant"), column: Some("id"), datatype: None, constraint: None, file: Some("execMain.c"), line: Some(2006), routine: Some("ExecConstraints") }
```