### PR TITLE
feat: adjusting google upload appearance

### DIFF
--- a/apps/chat-web/app/components/library/files/google-file-upload.tsx
+++ b/apps/chat-web/app/components/library/files/google-file-upload.tsx
@@ -36,8 +36,8 @@ export const GoogleFileUploadButton = ({ libraryId, disabled }: GoogleFileUpload
     <>
       <button
         type="button"
-        className="btn btn-xs tooltip tooltip-bottom"
-        data-tip={t('tooltips.addGoogleDriveFiles')}
+        className="btn btn-primary btn-xs tooltip tooltip-bottom"
+        data-tip={t('tooltips.googleDriveUpload')}
         onClick={() => {
           if (googleDriveAccessToken) {
             dialogRef.current?.showModal()
@@ -46,7 +46,7 @@ export const GoogleFileUploadButton = ({ libraryId, disabled }: GoogleFileUpload
           }
         }}
       >
-        <span className="hidden sm:inline">{t('libraries.googleDrive')}</span>
+        {t('libraries.googleDrive')}
       </button>
       <dialog ref={dialogRef} className="modal">
         <div className="modal-box relative flex w-full min-w-[400px] max-w-screen-lg flex-col">

--- a/apps/chat-web/app/i18n/de.ts
+++ b/apps/chat-web/app/i18n/de.ts
@@ -389,6 +389,7 @@ export default {
     edit: 'Bearbeiten',
     hide: 'Verbergen',
     goToOverview: 'Zur Übersicht',
+    googleDriveUpload: 'Aus Google Drive hochladen',
     leaveConversation: 'Konversation verlassen',
     remainingMessages: 'Nachrichten übrig',
     removeProfile: 'Benutzerprofil entfernen',

--- a/apps/chat-web/app/i18n/en.ts
+++ b/apps/chat-web/app/i18n/en.ts
@@ -380,6 +380,7 @@ export default {
     edit: 'Edit',
     hide: 'Hide',
     goToOverview: 'Go to overview',
+    googleDriveUpload: 'Upload from Google Drive',
     leaveConversation: 'Leave conversation',
     remainingMessages: 'Messages left',
     removeProfile: 'Remove profile',


### PR DESCRIPTION
Closes #637 

![image](https://github.com/user-attachments/assets/78db8f8e-dfd9-414c-84b2-d7eebc387f2d)

no need for sm:inline as its already inline
taking out hidden attribute so it now stays the same when on smaller resolution
adjusting overall appearance to other buttons