### PR TITLE
fix: conversations unchecking when changing language

### DIFF
--- a/apps/chat-web/app/components/conversation/conversation-selector.tsx
+++ b/apps/chat-web/app/components/conversation/conversation-selector.tsx
@@ -102,6 +102,7 @@ export const ConversationSelector = ({
                         type="checkbox"
                         className="checkbox checkbox-xs"
                         onChange={() => handleCheckConversation(conversation.id)}
+                        checked={checkedConversationIds.includes(conversation.id)}
                       />
                     </label>
 


### PR DESCRIPTION
Closes #630 

conversations now stay checked after changing language