### PR TITLE
nailed old Docker Image to debian bookworm because trixi destroyed it

### DIFF
--- a/apps/crawler-server/Dockerfile
+++ b/apps/crawler-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 # Install system dependencies (if needed)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl git openssh-client \


### PR DESCRIPTION
The problem was caused by latest debian release "trixie". We used bookworm but never nailed the version to use in the dockerfile.

Attention: FROM python:3.11-slim uses the latest debian, which can change in future. using FROM python:3.11-slim-bookworm nails it to bookworm.

Closes #719 

