### PR TITLE
fixed cookie context for mulit-host prod deployments

### DIFF
--- a/apps/chat-web/app/auth/auth.tsx
+++ b/apps/chat-web/app/auth/auth.tsx
@@ -38,10 +38,10 @@ const setKeycloakTokenInCookie = createServerFn({ method: 'POST' })
     const request = getWebRequest()
     const url = new URL(request?.url || '')
     const hostname = url.hostname
-    
+
     // Check if hostname is an IP address (IPv4 pattern)
     const isIpAddress = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)
-    
+
     if (isIpAddress || hostname === 'localhost' || !hostname.includes('.')) {
       // For IP addresses, localhost, or simple hostnames, don't set domain (use default)
       setCookie(KEYCLOAK_TOKEN_COOKIE_NAME, token)


### PR DESCRIPTION
we had trouble sending the cookie to other urls than the origin. At cheplapharm the web is:

web.cheplapharm.george-ai.net

and the download link for images is:

api.cheplapharm.george-ai.net

so auth is checked when downloading files from api but auth cookie token was not send because it originates from web. In local dev this is no issue because both is localhost, only the port is different. In prod this is an issue.

I tested it for both: dev with localhost and the above chepla urls. Both workls now.