### PR TITLE
fix: revert git config and regenerate lockfile for Docker builds

### DIFF
--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git to use HTTPS instead of SSH
-        run: 'git config --global url."https://github.com/".insteadOf git@github.com:'
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -28,8 +26,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git to use HTTPS instead of SSH
-        run: 'git config --global url."https://github.com/".insteadOf git@github.com:'
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -59,8 +55,6 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git to use HTTPS instead of SSH
-        run: 'git config --global url."https://github.com/".insteadOf git@github.com:'
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -82,8 +76,6 @@ jobs:
       postgres: *postgres_service
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git to use HTTPS instead of SSH
-        run: 'git config --global url."https://github.com/".insteadOf git@github.com:'
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -109,8 +101,6 @@ jobs:
       postgres: *postgres_service
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git to use HTTPS instead of SSH
-        run: 'git config --global url."https://github.com/".insteadOf git@github.com:'
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/apps/georgeai-backend/Dockerfile
+++ b/apps/georgeai-backend/Dockerfile
@@ -42,9 +42,6 @@ COPY packages/pothos-graphql/package.json ./packages/pothos-graphql/
 COPY packages/web-utils/package.json ./packages/web-utils/
 COPY apps/georgeai-backend/package.json ./apps/georgeai-backend/
 
-# Configure git to use HTTPS instead of SSH for dependency installation
-RUN git config --global url."https://github.com/".insteadOf git@github.com:
-
 RUN pnpm i --frozen-lockfile
 
 # Copy LICENSE file for legal compliance

--- a/apps/georgeai-web/Dockerfile
+++ b/apps/georgeai-web/Dockerfile
@@ -13,9 +13,6 @@ COPY turbo.json ./
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/georgeai-web/package.json ./apps/georgeai-web/
 
-# Configure git to use HTTPS instead of SSH for dependency installation
-RUN git config --global url."https://github.com/".insteadOf git@github.com:
-
 # Install dependencies
 RUN pnpm install --frozen-lockfile --filter @george-ai/web
 

--- a/apps/georgeai-webapp/Dockerfile
+++ b/apps/georgeai-webapp/Dockerfile
@@ -28,9 +28,6 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/web-utils/package.json ./packages/web-utils/
 COPY apps/georgeai-webapp/package.json ./apps/georgeai-webapp/
 
-# Configure git to use HTTPS instead of SSH for dependency installation
-RUN git config --global url."https://github.com/".insteadOf git@github.com:
-
 RUN pnpm i --frozen-lockfile
 
 # Copy source files afterwards to allow Docker layer caching

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1177,8 +1177,8 @@ packages:
   '@emmetio/css-abbreviation@2.1.8':
     resolution: {integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==}
 
-  '@emmetio/css-parser@git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660':
-    resolution: {commit: 370c480ac103bd17c7bcfb34bf5d577dc40d3660, repo: git@github.com:ramya-rao-a/css-parser.git, type: git}
+  '@emmetio/css-parser@https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660':
+    resolution: {tarball: https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660}
     version: 0.4.0
 
   '@emmetio/html-matcher@1.3.0':
@@ -9559,7 +9559,7 @@ snapshots:
     dependencies:
       '@emmetio/scanner': 1.0.4
 
-  '@emmetio/css-parser@git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660':
+  '@emmetio/css-parser@https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660':
     dependencies:
       '@emmetio/stream-reader': 2.2.0
       '@emmetio/stream-reader-utils': 0.1.0
@@ -17442,7 +17442,7 @@ snapshots:
 
   volar-service-emmet@0.0.65(@volar/language-service@2.4.23):
     dependencies:
-      '@emmetio/css-parser': git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660
+      '@emmetio/css-parser': https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.11.0
       vscode-uri: 3.1.0


### PR DESCRIPTION
## Problem

Docker builds for backend, webapp, and web were failing with:
```
/bin/sh: 1: git: not found
ERROR: failed to build: exit code: 127
```

## Root Cause

1. The vite update (PR #817) added git config workaround for SSH dependencies
2. This caused pnpm-lock.yaml to resolve `@emmetio/css-parser` via **git SSH** instead of **HTTPS tarball**
3. Docker builds run `pnpm install` inside containers that:
   - Don't have git installed (node:22-slim base image)
   - Are isolated from host git config
4. Result: pnpm tries to `git clone git@github.com:...` and fails

## Solution

**Removed git config workaround entirely:**
- ❌ Removed git config from all 5 workflow jobs
- ❌ Removed git config from all 3 Dockerfiles (backend, webapp, web)

**Regenerated lockfile to use tarball format:**
- ✅ `@emmetio/css-parser` now resolves via `https://codeload.github.com/.../tar.gz/...`
- ✅ No git installation needed
- ✅ Works in GitHub Actions and Docker builds

## Changes

- `.github/workflows/basic-checks.yml` - Removed git config from all jobs
- `apps/georgeai-backend/Dockerfile` - Removed git config
- `apps/georgeai-webapp/Dockerfile` - Removed git config  
- `apps/georgeai-web/Dockerfile` - Removed git config
- `pnpm-lock.yaml` - Regenerated with tarball format

## Testing

This PR will test:
- ✅ GitHub Actions workflows (lint, typecheck, build, test)
- ✅ Docker builds (backend, webapp, web)

Expected: All checks pass without git installation or git config.