### PR TITLE
chore(deps): configure dependabot to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # npm dependencies (monorepo)
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    groups:
+      production-dependencies:
+        dependency-type: 'production'
+      development-dependencies:
+        dependency-type: 'development'
+    commit-message:
+      prefix: 'chore(deps)'
+
+  # GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: 'ci'
+
+  # Docker
+  - package-ecosystem: 'docker'
+    directory: '/.devcontainer'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: 'chore(docker)'


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration to reduce the number of PRs by grouping updates and scheduling them weekly.

## Changes

- **Grouped npm dependencies**: Production and development dependencies each get their own PR instead of one PR per package
- **Weekly schedule**: Updates only run on Mondays instead of immediately
- **Limited open PRs**: Maximum 5 npm PRs, 2 for Actions/Docker
- **Monthly updates**: GitHub Actions and Docker images updated monthly
- **Consistent commit messages**: Proper conventional commit prefixes

## Benefits

- Fewer notifications and PR clutter
- Easier to review grouped dependencies together
- Predictable update schedule (Mondays)
- Still maintains security by getting weekly updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)