### PR TITLE
Fix: Prevent duplicate Docker build workflow runs

### DIFF
--- a/.github/workflows/build-publish-dockers.yml
+++ b/.github/workflows/build-publish-dockers.yml
@@ -1,10 +1,10 @@
 name: Build and publish Docker images
 
 on:
-  # Only publish Docker images after all quality checks pass on main
+  # Only publish Docker images after E2E tests pass on main
+  # (E2E tests depend on basic checks, so this ensures all quality checks passed)
   workflow_run:
     workflows:
-      - 'Basic linting, formatting and building'
       - 'E2E Tests'
     types:
       - completed


### PR DESCRIPTION
## Summary

Fixes duplicate "Build and publish Docker images" workflow runs that occur when merging to main.

## Problem

Currently, the Docker build workflow is triggered by **two** separate workflows:
1. "Basic linting, formatting and building"
2. "E2E Tests"

When a PR is merged to main:
- Both workflows complete successfully
- Each completion triggers the Docker build workflow
- Result: 2 identical Docker build runs 

## Solution

Only trigger Docker builds after **E2E Tests** complete.

Since E2E tests are the most comprehensive quality checks, waiting for them to pass is sufficient to ensure all checks have passed before publishing Docker images.

## Changes

- Updated `workflow_run` trigger to only listen to "E2E Tests" workflow
- Removed "Basic linting, formatting and building" from trigger list
- Added clarifying comment about why this approach works

## Impact

- **Before**: 2 Docker build workflow runs per main branch push
- **After**: 1 Docker build workflow run per main branch push
- No loss of quality assurance (E2E tests are still required to pass)
- Reduced CI/CD resource usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)