### PR TITLE
fix(e2e): make marketing website URL configurable for local testing

### DIFF
--- a/e2e-tests/.env.example
+++ b/e2e-tests/.env.example
@@ -26,6 +26,18 @@
 # - Testing production: BASE_URL=https://app.george-ai.net
 
 # -------------------------------------------------------------------
+# Marketing Website URL (OPTIONAL)
+# -------------------------------------------------------------------
+# URL where the marketing website (georgeai-web) is running. Defaults to http://localhost:4321
+# For docker-compose.local.yml (which uses port 4331 to avoid conflicts):
+MARKETING_WEBSITE_URL=http://localhost:4331
+#
+# Examples:
+# - Local pnpm dev: MARKETING_WEBSITE_URL=http://localhost:4321 (default)
+# - docker-compose.local: MARKETING_WEBSITE_URL=http://localhost:4331
+# - CI: Uses default port 4321
+
+# -------------------------------------------------------------------
 # Database Connection (REQUIRED)
 # -------------------------------------------------------------------
 # Used by test setup to create test workspaces via SQL

--- a/e2e-tests/src/marketing-website.spec.ts
+++ b/e2e-tests/src/marketing-website.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-const MARKETING_WEBSITE_URL = 'http://localhost:4321'
+const MARKETING_WEBSITE_URL = process.env.MARKETING_WEBSITE_URL || 'http://localhost:4321'
 const EXPECTED_DISCORD_URL = process.env.EXPECTED_DISCORD_URL || 'https://discord.gg/GbQFKb2MNJ'
 
 test.describe('Marketing Website', () => {


### PR DESCRIPTION
## Summary

Fixes E2E test failures when using `docker-compose.local.yml` by making the marketing website URL configurable.

## Problem

- **docker-compose.local.yml** uses port **4331** for the marketing website to avoid conflicts with `pnpm dev` (port 4321)
- **Marketing website tests** were hardcoded to `http://localhost:4321`
- This caused test failures when running E2E tests with docker-compose locally
- Users need to run both `pnpm dev` and docker-compose simultaneously

## Solution

Made `MARKETING_WEBSITE_URL` configurable via environment variable:
- **Default**: `http://localhost:4321` (matches CI and `pnpm dev`)
- **Override**: `http://localhost:4331` (for `docker-compose.local.yml`)

## Changes

- **e2e-tests/src/marketing-website.spec.ts**: Use `process.env.MARKETING_WEBSITE_URL` instead of hardcoded URL
- **e2e-tests/.env.example**: Document `MARKETING_WEBSITE_URL` with usage examples

## Testing

### For docker-compose.local.yml users:
```bash
# Add to e2e-tests/.env
MARKETING_WEBSITE_URL=http://localhost:4331

# Run tests
cd e2e-tests
pnpm test src/marketing-website.spec.ts
```

### For pnpm dev users:
```bash
# No config needed - uses default port 4321
cd e2e-tests
pnpm test src/marketing-website.spec.ts
```

### CI:
- No changes needed - CI already uses port 4321 (default)

## Benefits

- ✅ Supports both `pnpm dev` and `docker-compose.local.yml` workflows
- ✅ No conflicts when running services simultaneously
- ✅ Backward compatible (defaults to existing behavior)
- ✅ Well documented in `.env.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)