### PR TITLE
fix: html in csv works now as intended

### DIFF
--- a/packages/file-converter/src/converters/csv-to-markdown.ts
+++ b/packages/file-converter/src/converters/csv-to-markdown.ts
@@ -49,9 +49,14 @@ function generateRowMarkdown(headers: string[], row: string[], rowNumber: number
   for (let i = 0; i < headers.length; i++) {
     const header = headers[i] || `Column ${i + 1}`
     const value = row[i] || ''
-
+    if (value.trim() === '') {
+      continue
+    }
     // Simple format: "Header: value" - no sub-sections
-    lines.push(`**${header}:** ${value}`)
+    lines.push(`**${header}:**`)
+    lines.push(`\`\`\``)
+    lines.push(`${value}`)
+    lines.push(`\`\`\``)
   }
 
   return lines.join('\n')

--- a/packages/file-converter/src/converters/testing/csv-to-markdown.test.ts
+++ b/packages/file-converter/src/converters/testing/csv-to-markdown.test.ts
@@ -1,0 +1,79 @@
+import { resolve } from 'path'
+import { describe, expect, it, vi } from 'vitest'
+
+import { saveMarkdownContent } from '@george-ai/file-management'
+
+import { transformCsvToMarkdown } from '../csv-to-markdown'
+
+vi.mock('@george-ai/file-management', () => ({
+  deleteExistingExtraction: vi.fn(),
+  getFileDir: vi.fn(() => '/mock/dir'),
+  saveMarkdownContent: vi.fn(),
+}))
+
+describe('csvToMarkdownConverter', () => {
+  const abortSignal = new AbortController().signal
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should convert basic csv to markdown', async () => {
+    const csvPath = resolve(__dirname, 'test.csv')
+
+    const basicExtraction = await transformCsvToMarkdown(csvPath, abortSignal, 'test-lib', 'test-file', 'test.csv')
+
+    // confirm total parts and header
+    expect(basicExtraction.metadata?.rowCount).toBe(2)
+    expect(basicExtraction.metadata?.headers).toEqual(['Name', 'Age', 'City', ''])
+
+    const firstPart = vi.mocked(saveMarkdownContent).mock.calls[0][0]
+    expect(firstPart.part).toBe(1)
+    expect(firstPart.markdown).toMatch(/# CSV Row 1/)
+    expect(firstPart.markdown).toContain('**Name:**')
+    expect(firstPart.markdown).toContain('```\nGeorge AI\n```')
+    expect(firstPart.markdown).toContain('**Age:**')
+    expect(firstPart.markdown).toContain('```\n30\n```')
+    expect(firstPart.markdown).toContain('**City:**')
+    expect(firstPart.markdown).toContain('```\nGreifswald\n```')
+
+    const secondPart = vi.mocked(saveMarkdownContent).mock.calls[1][0]
+    expect(secondPart.part).toBe(2)
+    expect(secondPart.markdown).toMatch(/# CSV Row 2/)
+    expect(secondPart.markdown).toContain('**Name:**')
+    expect(secondPart.markdown).toContain('```\nBob\n```')
+    expect(secondPart.markdown).toContain('**Age:**')
+    expect(secondPart.markdown).toContain('```\n55\n```')
+    expect(secondPart.markdown).toContain('**City:**')
+    expect(secondPart.markdown).toContain('```\nCologne\n```')
+  }, 10000)
+
+  it('should convert csv containing html to markdown', async () => {
+    const csvPath = resolve(__dirname, 'testHtml.csv')
+
+    const htmlExtraction = await transformCsvToMarkdown(csvPath, abortSignal, 'test-lib', 'test-file', 'testHtml.csv')
+
+    expect(htmlExtraction.metadata?.rowCount).toBe(2)
+    expect(htmlExtraction.metadata?.headers).toEqual(['Name', 'Age', 'City', ''])
+
+    const firstPart = vi.mocked(saveMarkdownContent).mock.calls[0][0]
+    expect(firstPart.part).toBe(1)
+    expect(firstPart.markdown).toMatch(/# CSV Row 1/)
+    expect(firstPart.markdown).toContain('**Name:**')
+    expect(firstPart.markdown).toContain('```\n<a>George AI</a>\n```')
+    expect(firstPart.markdown).toContain('**Age:**')
+    expect(firstPart.markdown).toContain('```\n30\n```')
+    expect(firstPart.markdown).toContain('**City:**')
+    expect(firstPart.markdown).toContain('```\n<body> Greifswald </body>\n```')
+
+    const secondPart = vi.mocked(saveMarkdownContent).mock.calls[1][0]
+    expect(secondPart.part).toBe(2)
+    expect(secondPart.markdown).toMatch(/# CSV Row 2/)
+    expect(secondPart.markdown).toContain('**Name:**')
+    expect(secondPart.markdown).toContain('```\nBob\n```')
+    expect(secondPart.markdown).toContain('**Age:**')
+    expect(secondPart.markdown).toContain('```\n<br> 55 </br>\n```')
+    expect(secondPart.markdown).toContain('**City:**')
+    expect(secondPart.markdown).toContain('```\n<p>Cologne</p>\n```')
+  }, 10000)
+})

--- a/packages/file-converter/src/converters/testing/test.csv
+++ b/packages/file-converter/src/converters/testing/test.csv
@@ -1,0 +1,3 @@
+Name,Age,City,
+George AI,30,Greifswald,
+Bob, 55, Cologne,

--- a/packages/file-converter/src/converters/testing/testHtml.csv
+++ b/packages/file-converter/src/converters/testing/testHtml.csv
@@ -1,0 +1,3 @@
+Name,Age,City,
+<a>George AI</a>,30,<body> Greifswald </body>,
+Bob, <br> 55 </br>, <p>Cologne</p>,


### PR DESCRIPTION
## Description

HTML in csv files causes extracted parts to be broken. Extracted parts (values) now get broken into code blocks, which will no longer break the extracted parts itself. 

## Related Issues

Does not exist as a listed issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- extracted data is now in code blocks
- added a testing folder for testing files
- added csv-to-markdown.test.ts, for validating intended outputs
- added two .csv for testing purposes

## Checklist

- [x] I have run `pnpm format` before committing
- [x] My code passes `pnpm typecheck`
- [x] My code passes `pnpm lint`
- [x] I have added tests for my changes (if applicable)
- [x] All tests pass (`pnpm test`)
- [x] I have updated the documentation (if applicable)
- [x] I have tested my changes locally
- [x] My commits follow the [commit message guidelines](https://github.com/progwise/george-ai/blob/main/.github/CONTRIBUTING.md#commit-message-guidelines)