### PR TITLE
fix: enrichment dialogue now always shows correct values

### DIFF
--- a/apps/georgeai-webapp/src/components/lists/field-modal.tsx
+++ b/apps/georgeai-webapp/src/components/lists/field-modal.tsx
@@ -118,11 +118,13 @@ export const FieldModal = ({ list, maxOrder, editField, ref }: FieldModalProps) 
   const fullContents = useMemo(() => editField?.contextFullContents || [], [editField])
 
   const isEditMode = useMemo(() => !!editField, [editField])
+  const formRef = React.useRef<HTMLFormElement | null>(null)
 
   const handleCloseModal = () => {
     setActiveTab('instruction')
     setContextSubTab('fields')
     ref.current?.close()
+    formRef.current?.reset()
   }
 
   const schema = useMemo(
@@ -344,12 +346,12 @@ export const FieldModal = ({ list, maxOrder, editField, ref }: FieldModalProps) 
 
   return (
     <dialog ref={ref} className="modal">
-      <div className="modal-box flex h-[80vh] max-h-[800px] w-11/12 max-w-3xl flex-col">
+      <div className="modal-box flex h-[80vh] max-h-200 w-11/12 max-w-3xl flex-col">
         <h3 className="mb-4 shrink-0 text-lg font-bold">
           {t(isEditMode ? 'lists.fields.editTitle' : 'lists.fields.addTitle')}
         </h3>
 
-        <form onSubmit={handleSubmit} noValidate className="flex min-h-0 flex-1 flex-col">
+        <form ref={formRef} onSubmit={handleSubmit} noValidate className="flex min-h-0 flex-1 flex-col">
           {/* Hidden Fields */}
           <input type="hidden" name="id" value={fieldId} />
           <input type="hidden" name="listId" value={list.id} />

--- a/apps/georgeai-webapp/src/i18n/de.ts
+++ b/apps/georgeai-webapp/src/i18n/de.ts
@@ -762,6 +762,7 @@ export default {
     fields: {
       addField: 'Feld hinzufügen',
       addSuccess: 'Feld "{name}" erfolgreich hinzugefügt',
+      addTitle: 'Neues Feld hinzufügen',
       aiModel: 'Sprachmodell',
       aiPrompt: 'Prompt',
       aiPromptHelp: 'Dieser Prompt wird verwendet, um den Wert des Feldes für jede Datei zu berechnen.',

--- a/apps/georgeai-webapp/src/i18n/en.ts
+++ b/apps/georgeai-webapp/src/i18n/en.ts
@@ -752,6 +752,7 @@ export default {
     fields: {
       addField: 'Add Field',
       addSuccess: 'Field "{name}" added successfully',
+      addTitle: 'Add Field',
       aiModel: 'Large Language Model',
       aiPrompt: 'Prompt',
       aiPromptHelp: 'This prompt is used to calculate the value of the field for each file.',


### PR DESCRIPTION
## Description

Adding or editing enrichment dialogue won't show wrong values anymore.

## Related Issues

Closes #998

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- added ref to firm in field-modal.tsx

## Checklist

- [x] I have run `pnpm format` before committing
- [x] My code passes `pnpm typecheck`
- [x] My code passes `pnpm lint`
- [x] I have added tests for my changes (if applicable)
- [x] All tests pass (`pnpm test`)
- [x] I have updated the documentation (if applicable)
- [x] I have tested my changes locally
- [x] My commits follow the [commit message guidelines](https://github.com/progwise/george-ai/blob/main/.github/CONTRIBUTING.md#commit-message-guidelines)
